### PR TITLE
Fix tests

### DIFF
--- a/firefox-X11/.skiptest
+++ b/firefox-X11/.skiptest
@@ -1,0 +1,3 @@
+Skips the current directory during automated test runs.
+
+Skipping this test because it is run non-headless, which does not fly in a VM for our automated tests.

--- a/stress-10/build.sh
+++ b/stress-10/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker compose -f ../shared/stress/compose.yml build

--- a/stress-step/build.sh
+++ b/stress-step/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker compose -f ../shared/stress/compose.yml build

--- a/stress/build.sh
+++ b/stress/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker compose -f ../shared/stress/compose.yml build

--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -36,8 +36,12 @@ def example_directories():
 def test_all_directories(example_directory, capsys):
     project_name = f"test_{utils.randomword(12)}"
 
-    # Docker compose build example application
-    subprocess.run(["docker", "compose", "-f", f"{example_directory}/compose.yml", "build"])
+        # This is needed so that examples whose compose's are lesewhere (such as the shared
+        # directory for the stress tests, still get built
+    if os.path.exists(f"{example_directory}/build.sh"):
+        subprocess.run(["bash", f"{example_directory}/build.sh"])
+    else:
+        subprocess.run(["docker", "compose", "-f", f"{example_directory}/compose.yml", "build"])
 
     # Insert Project into testing DB
     project_id = DB().fetch_one('INSERT INTO "projects" ("name","uri","email","last_run","created_at") \


### PR DESCRIPTION
-added build.sh script to stress examples, tests will now try to look/build this file first, and only try docker compose second; 
- skip browser test that runs in head mode, as it wont work in VM