### PR TITLE
Nextcloud playwright

### DIFF
--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/playwright/python:v1.35.0-jammy
+
+# Install dependencies
+RUN apt-get update && apt-get install -y  curl  wget  gnupg  && rm -rf /var/lib/apt/lists/*
+
+# Install Playwright
+RUN pip install playwright==1.35.0
+
+# Set up Playwright dependencies for Chromium, Firefox and Webkit
+RUN playwright install
+RUN playwright install-deps
+
+CMD ["/bin/bash"]

--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -1,0 +1,73 @@
+# Benchmarking Nextcloud
+
+What is Nextcloud? A safe home for all your data. Access & share your files, calendars, contacts, mail & more from any device, on your terms.
+
+Most of the Nextcloud is based of the code supplied in <https://github.com/nextcloud/docker> please refer to this documentation for everything Nextcloud dependent.
+
+We evaluate the two browsers Chromium and Firefox. Also the three databases MariaDB, Postgres and SQLite.
+
+There are two main ways to deploy Nextcloud with docker. One is via apache and one is using FPM.
+
+## Scenarios
+
+Currently there are three different usage scenarios of Nextcloud, orchestrated with different databases and browsers.
+All scripts will start of with creating an admin account and installing the recommended apps,  
+then each case diverges from that point.
+The cases are:
+
+- Event:
+  + Login as admin and create a calendar event and validate that it is visible.
+- Docs:
+  + Login as admin and create a second user.
+  + Login as admin and create a text document and then share it with second user
+  + Login as both users, open the text document and edit it, making sure the other user sees the text entered
+- Talk:
+  + Login as admin and create a group chat, allowing guests to join via link
+  + Open the group conversation link in 5 browsers as guests
+  + Each guest sends a 20KB random text message and validates the other members have received it
+
+These scripts are implemented in Playwright Python
+
+## Playwright files
+
+- `nextcloud_install.py`: Installs Nextcloud and creates a admin user. Also installs all apps that are
+  available.
+- `nextcloud_create_event.py`: This script logs into Nextcloud and then creates an event and checks if it then  subsequently shows up in the calender view.
+- `nextcloud_talk.py`: Login, create group conversation that is open to guests, then open the chat as 5 guests and send messages, validating each message is received by the other chat members.
+- `nextcloud_create_user.py`: Logs into Nextcloud as an admin and creates a second user
+- `nextcloud_create_doc_and_share.py`: Login as admin and create a text document, sharing it with the second user
+- `nextcloud_docs_collaborate.py`: Login as both admin and 2nd user, open the doc and edit it together, validating the edits from the other user.
+
+## Infrastructure
+
+### apache
+
+The compose file is copy pasted from <https://github.com/nextcloud/docker#base-version---apache>
+We set a bogus password for `*_ROOT_PASSWORD` and `*_PASSWORD` as the GMT requires environment variables to be set.
+
+### FPM
+
+The compose file is copy pasted from <https://github.com/nextcloud/docker#base-version---fpm>
+Again with bogus passwords as with apache.
+
+## Running
+
+You will need to supply the `--skip-unsafe` to the runner as there are ports defined in the `compose.yml`
+
+## Debugging tips
+
+Sometimes the playwright files will fail and it is unclear why. To easily debug this uncomment
+
+```yml
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+```
+
+in the `usage_scenario*.yml` file.
+Then enable head full mode by `headless: false,` in the playwright file. Don't forget to `xhost +` on the host system.
+If you have multiple displays you will also need to edit the `DISPLAY: ":0"`.
+
+In cases where the script hangs because of a wrong locator, it might be helpful to run the usage scenario in debug mode and then attach a shell to the Playwright container.
+Running `playwright codegen -o output.py` from the container and then following the actions of the script can help investigate what exactly is different.

--- a/nextcloud/compose-fpm-mariadb.yml
+++ b/nextcloud/compose-fpm-mariadb.yml
@@ -1,0 +1,44 @@
+version: '2'
+
+volumes:
+  nextcloud:
+  db:
+
+services:
+  db:
+    image: mariadb:10.6
+    restart: always
+    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
+    volumes:
+      - db:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=TheGibson
+      - MYSQL_PASSWORD=TheGibson
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+
+  app:
+    image: nextcloud:27.0.0-fpm
+    restart: always
+    links:
+      - db
+    volumes:
+      - nextcloud:/var/www/html
+    environment:
+      - MYSQL_PASSWORD=TheGibson
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_HOST=db
+
+  nc:
+    image: nginx:alpine
+    restart: always
+    ports:
+      - 8080:80
+    links:
+      - app
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - nextcloud:/var/www/html:ro
+    depends_on:
+      - app

--- a/nextcloud/compose-fpm-mariadb.yml
+++ b/nextcloud/compose-fpm-mariadb.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:11.0.2-jammy
     restart: always
     command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
     volumes:
@@ -31,7 +31,7 @@ services:
       - MYSQL_HOST=db
 
   nc:
-    image: nginx:alpine
+    image: nginx:1.25.1-alpine3.17
     restart: always
     ports:
       - 8080:80

--- a/nextcloud/compose-mariadb.yml
+++ b/nextcloud/compose-mariadb.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:11.0.2-jammy
     restart: always
     command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
     volumes:

--- a/nextcloud/compose-mariadb.yml
+++ b/nextcloud/compose-mariadb.yml
@@ -1,0 +1,33 @@
+version: '2'
+
+volumes:
+  nextcloud:
+  db:
+
+services:
+  db:
+    image: mariadb:10.6
+    restart: always
+    command: --transaction-isolation=READ-COMMITTED --log-bin=binlog --binlog-format=ROW
+    volumes:
+      - db:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=TheGibson
+      - MYSQL_PASSWORD=TheGibson
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+
+  nc:
+    image: nextcloud:27.0.0-apache
+    restart: always
+    ports:
+      - 8080:80
+    links:
+      - db
+    volumes:
+      - nextcloud:/var/www/html
+    environment:
+      - MYSQL_PASSWORD=TheGibson
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_HOST=db

--- a/nextcloud/compose-postgres.yml
+++ b/nextcloud/compose-postgres.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   db:
-    image: postgres:alpine
+    image: postgres:15.3-alpine3.18
     restart: always
     volumes:
       - db:/var/lib/postgresql/data:Z

--- a/nextcloud/compose-postgres.yml
+++ b/nextcloud/compose-postgres.yml
@@ -1,0 +1,31 @@
+version: '2'
+
+volumes:
+  nextcloud:
+  db:
+
+services:
+  db:
+    image: postgres:alpine
+    restart: always
+    volumes:
+      - db:/var/lib/postgresql/data:Z
+    environment:
+      - POSTGRES_PASSWORD=TheGibson
+      - POSTGRES_DB=nextcloud
+      - POSTGRES_USER=nextcloud
+
+  nc:
+    image: nextcloud:27.0.0-apache
+    restart: always
+    ports:
+      - 8080:80
+    links:
+      - db
+    volumes:
+      - nextcloud:/var/www/html
+    environment:
+      - POSTGRES_PASSWORD=TheGibson
+      - POSTGRES_DB=nextcloud
+      - POSTGRES_USER=nextcloud
+      - POSTGRES_HOST=db

--- a/nextcloud/compose-sqlite.yml
+++ b/nextcloud/compose-sqlite.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+  nc:
+    image: nextcloud:27.0.0-apache
+    restart: always
+    ports:
+      - 8080:80
+    volumes:
+      - nextcloud:/var/www/html

--- a/nextcloud/nextcloud_create_doc_and_share.py
+++ b/nextcloud/nextcloud_create_doc_and_share.py
@@ -1,0 +1,65 @@
+import contextlib
+import sys
+from time import sleep, time_ns
+
+from playwright.sync_api import Playwright, sync_playwright, Error
+
+def log_note(message: str) -> None:
+    timestamp = str(time_ns())[:16]
+    print(f"{timestamp} {message}")
+
+def run(playwright: Playwright, browser_name: str) -> None:
+    log_note(f"Launch browser {browser_name}")
+    if browser_name == "firefox":
+        browser_type = playwright.firefox
+    else:
+        browser_type = playwright.chromium
+    browser = browser_type.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+    try:
+        log_note("Login")
+        page.goto("http://nc/")
+        page.get_by_label("Account name or email").click()
+        page.get_by_label("Account name or email").fill("Crash")
+        page.get_by_label("Account name or email").press("Tab")
+        page.get_by_label("Password", exact=True).fill("Override")
+        page.get_by_label("Password", exact=True).press("Enter")
+        log_note("Create new text file")
+        page.get_by_role("link", name="Files").click()
+        page.get_by_role("link", name="New file/folder menu").click()
+        page.get_by_role("link", name="New text file").click()
+        page.locator("#view7-input-file").fill("colab_meeting.md")
+        page.locator("#view7-input-file").press("Enter")
+        page.get_by_role("button", name="Create a new file with the selected template").click()
+        sleep(5)
+        with contextlib.suppress(Exception):
+            page.get_by_role("button", name="Close modal").click(timeout=15_000)
+        page.keyboard.press("Escape")
+        log_note("Share file with other user")
+        page.get_by_role("link", name="colab_meeting .md").get_by_role("link", name="Share").click()
+        page.get_by_placeholder("Name, email, or Federated Cloud ID …").click()
+        page.get_by_placeholder("Name, email, or Federated Cloud ID …").fill("docs")
+        page.get_by_text("docs_dude").first.click()
+        log_note("Close browser")
+        page.close()
+
+        # ---------------------
+        context.close()
+        browser.close()
+    except Error as e:
+        log_note(f"Exception occurred: {e.message}")
+        log_note(f"Page content was: {page.content()}")
+        raise e
+
+
+with sync_playwright() as playwright:
+    if len(sys.argv) > 1:
+        browser_name = sys.argv[1].lower()
+        if browser_name not in ["chromium", "firefox"]:
+            print("Invalid browser name. Please choose either 'chromium' or 'firefox'.")
+            sys.exit(1)
+    else:
+        browser_name = "chromium"
+
+    run(playwright, browser_name)

--- a/nextcloud/nextcloud_create_event.py
+++ b/nextcloud/nextcloud_create_event.py
@@ -1,0 +1,74 @@
+import contextlib
+import sys
+from time import time_ns, sleep
+
+from playwright.sync_api import Playwright, sync_playwright, expect, Error
+
+def log_note(message: str) -> None:
+    timestamp = str(time_ns())[:16]
+    print(f"{timestamp} {message}")
+
+def run(playwright: Playwright, browser_name: str) -> None:
+    log_note(f"Launch browser {browser_name}")
+    headless = True
+    if browser_name == "firefox":
+        browser = playwright.firefox.launch(headless=headless)
+    else:
+        browser = playwright.chromium.launch(headless=headless)
+
+    context = browser.new_context()
+    page = context.new_page()
+
+    try:
+        page.goto("http://nc/login")
+        log_note("Login")
+        page.get_by_label("Account name or email").fill("Crash")
+        page.get_by_label("Account name or email").press("Tab")
+        page.get_by_label("Password", exact=True).fill("Override")
+        page.get_by_label("Password", exact=True).press("Enter")
+        log_note("Wait for welcome popup")
+        # Sleep to make sure the modal has time to appear before continuing navigation
+        sleep(5)
+        log_note("Close welcome popup")
+        with contextlib.suppress(Exception):
+            page.get_by_role("button", name="Close modal").click(timeout=15_000)
+
+        log_note("Go to calendar")
+        page.get_by_role("link", name="Calendar").click()
+
+        # Second welcome screen?
+        with contextlib.suppress(Exception):
+            page.get_by_role("button", name="Close modal").click(timeout=15_000)
+
+        log_note("Create event")
+        event_name = "Weekly sync"
+        page.get_by_role("button", name="New event").click()
+        page.get_by_placeholder("Event title").fill(event_name)
+        page.get_by_role("button", name="Save").click()
+        log_note("Event created")
+        expect(page.get_by_text(event_name, exact=True)).to_be_visible()
+        page.close()
+        log_note("Close browser")
+
+    except Error as e:
+        log_note(f"Exception occurred: {e.message}")
+        log_note("Page content was:")
+        log_note(page.content())
+        raise e
+
+    # ---------------------
+    context.close()
+    browser.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        browser_name = sys.argv[1].lower()
+        if browser_name not in ["chromium", "firefox"]:
+            print("Invalid browser name. Please choose either 'chromium' or 'firefox'.")
+            sys.exit(1)
+    else:
+        browser_name = "chromium"
+
+    with sync_playwright() as playwright:
+        run(playwright, browser_name)

--- a/nextcloud/nextcloud_create_user.py
+++ b/nextcloud/nextcloud_create_user.py
@@ -1,0 +1,61 @@
+import sys
+import contextlib
+from time import time_ns
+
+from playwright.sync_api import Playwright, sync_playwright, Error
+
+def log_note(message: str) -> None:
+    timestamp = str(time_ns())[:16]
+    print(f"{timestamp} {message}")
+
+def create_user(playwright: Playwright, browser_name: str, username: str, password: str) -> None:
+    log_note(f"Launch browser {browser_name}")
+    if browser_name == "firefox":
+        browser_type = playwright.firefox
+    else:
+        browser_type = playwright.chromium
+    browser = browser_type.launch(headless=True)
+    context = browser.new_context()
+    try:
+        page = context.new_page()
+        log_note("Login")
+        page.goto("http://nc/")
+        page.get_by_label("Account name or email").click()
+        page.get_by_label("Account name or email").fill("Crash")
+        page.get_by_label("Account name or email").press("Tab")
+        page.get_by_label("Password", exact=True).fill("Override")
+        page.get_by_label("Password", exact=True).press("Enter")
+        with contextlib.suppress(Exception):
+            page.get_by_role("button", name="Close modal").click(timeout=15_000)
+        log_note("Create user")
+        page.get_by_role("link", name="Open settings menu").click()
+        page.get_by_role("link", name="Users").first.click()
+        page.get_by_role("button", name="New user").click()
+        page.get_by_placeholder("Username").click()
+        page.get_by_placeholder("Username").fill(username)
+        page.get_by_placeholder("Username").press("Tab")
+        page.get_by_placeholder("Display name").press("Tab")
+        page.get_by_placeholder("Password", exact=True).fill(password)
+        page.get_by_role("button", name="Add a new user").click()
+        log_note("Close browser")
+
+        # ---------------------
+        page.close()
+        context.close()
+        browser.close()
+    except Error as e:
+        log_note(f"Exception occurred: {e.message}")
+        log_note(f"Page content was: {page.content()}")
+        raise e
+
+
+with sync_playwright() as playwright:
+    if len(sys.argv) > 1:
+        browser_name = sys.argv[1].lower()
+        if browser_name not in ["chromium", "firefox"]:
+            print("Invalid browser name. Please choose either 'chromium' or 'firefox'.")
+            sys.exit(1)
+    else:
+        browser_name = "chromium"
+
+    create_user(playwright, browser_name, username="docs_dude", password="docsrule!12")

--- a/nextcloud/nextcloud_create_user.py
+++ b/nextcloud/nextcloud_create_user.py
@@ -30,6 +30,9 @@ def create_user(playwright: Playwright, browser_name: str, username: str, passwo
         log_note("Create user")
         page.get_by_role("link", name="Open settings menu").click()
         page.get_by_role("link", name="Users").first.click()
+        # Second welcome screen sometimes appears
+        with contextlib.suppress(Exception):
+            page.get_by_role("button", name="Close modal").click(timeout=15_000)
         page.get_by_role("button", name="New user").click()
         page.get_by_placeholder("Username").click()
         page.get_by_placeholder("Username").fill(username)

--- a/nextcloud/nextcloud_docs_collaboration.py
+++ b/nextcloud/nextcloud_docs_collaboration.py
@@ -59,14 +59,14 @@ def collaborate(playwright: Playwright, browser_name: str) -> None:
             if x % 2 == 0:
                 log_note("Admin adding text")
                 admin_user.get_by_role("dialog", name="colab_meeting.md").get_by_role("document").locator("div").first.type(random_message)
-                expect(docs_user.get_by_text(random_message)).to_be_visible()
+                expect(docs_user.get_by_text(random_message)).to_be_visible(timeout=15_000)
             else:
                 log_note("User adding text")
                 docs_user.get_by_role("dialog", name="colab_meeting.md").get_by_role("document").locator("div").first.type(random_message)
-                expect(admin_user.get_by_text(random_message)).to_be_visible()
+                expect(admin_user.get_by_text(random_message)).to_be_visible(timeout=15_000)
 
-            log_note("Sleeping for 10 seconds")
-            sleep(10)
+            log_note("Sleeping for 5 seconds")
+            sleep(5)
 
         log_note("Closing browsers")
         # ---------------------

--- a/nextcloud/nextcloud_docs_collaboration.py
+++ b/nextcloud/nextcloud_docs_collaboration.py
@@ -1,0 +1,104 @@
+import contextlib
+import random
+import string
+import sys
+from time import time_ns, sleep
+
+from playwright.sync_api import Playwright, sync_playwright, expect, Error
+
+
+def get_random_text() -> str:
+    size_in_bytes = 1024
+    characters = string.ascii_letters + string.digits
+    return ''.join(random.choice(characters) for _ in range(size_in_bytes))
+
+def log_note(message: str) -> None:
+    timestamp = str(time_ns())[:16]
+    print(f"{timestamp} {message}")
+
+def collaborate(playwright: Playwright, browser_name: str) -> None:
+    log_note(f"Launch two {browser_name} browsers")
+    if browser_name == "firefox":
+        browser_type = playwright.firefox
+    else:
+        browser_type = playwright.chromium
+
+    browser = browser_type.launch(headless=True)
+    context = browser.new_context()
+    admin_user = context.new_page()
+
+    browser_two = browser_type.launch(headless=True)
+    context_two = browser_two.new_context()
+    docs_user = context_two.new_page()
+
+    try:
+        # Login and open the file for both users
+        log_note("Logging in with users")
+        login(admin_user, "Crash", "Override")
+        login(docs_user, "docs_dude", "docsrule!12")
+        log_note("Opening document with both users")
+        with contextlib.suppress(Exception):
+            sleep(5)
+            docs_user.get_by_role("button", name="Close modal").click(timeout=15_000)
+        admin_user.get_by_role("link", name="Files").click()
+        docs_user.get_by_role("link", name="Files").click()
+        admin_user.get_by_role("link", name="Shares").click()
+        docs_user.get_by_role("link", name="Shares").click()
+        admin_user.get_by_role("link", name="colab_meeting .md").click()
+        docs_user.get_by_role("link", name="colab_meeting .md").click()
+
+        # Write the first message and assert it's visible for the other user
+        log_note("Sending first validation message")
+        first_message = "FIRST_VALIDATION_MESSAGE"
+        admin_user.get_by_role("dialog", name="colab_meeting.md").get_by_role("document").locator("div").first.type(first_message)
+        expect(docs_user.get_by_text(first_message)).to_be_visible()
+
+        for x in range(1, 7):
+            random_message = get_random_text()
+            # Admin sends on even, docs_dude on odd
+            if x % 2 == 0:
+                log_note("Admin adding text")
+                admin_user.get_by_role("dialog", name="colab_meeting.md").get_by_role("document").locator("div").first.type(random_message)
+                expect(docs_user.get_by_text(random_message)).to_be_visible()
+            else:
+                log_note("User adding text")
+                docs_user.get_by_role("dialog", name="colab_meeting.md").get_by_role("document").locator("div").first.type(random_message)
+                expect(admin_user.get_by_text(random_message)).to_be_visible()
+
+            log_note("Sleeping for 10 seconds")
+            sleep(10)
+
+        log_note("Closing browsers")
+        # ---------------------
+        admin_user.close()
+        docs_user.close()
+        context.close()
+        context_two.close()
+        browser.close()
+        browser_two.close()
+
+    except Error as e:
+        log_note(f"Exception occurred: {e.message}")
+        log_note(f"Page content was: {docs_user.content()}")
+        log_note(f"Page content was: {admin_user.content()}")
+        raise e
+
+def login(page, username, password):
+    page.goto("http://nc/login")
+    page.get_by_label("Account name or email").click()
+    page.get_by_label("Account name or email").fill(username)
+    page.get_by_label("Account name or email").press("Tab")
+    page.get_by_label("Password", exact=True).fill(password)
+    page.get_by_label("Password", exact=True).press("Enter")
+
+
+with sync_playwright() as playwright:
+    if len(sys.argv) > 1:
+        browser_name = sys.argv[1].lower()
+        if browser_name not in ["chromium", "firefox"]:
+            print("Invalid browser name. Please choose either 'chromium' or 'firefox'.")
+            sys.exit(1)
+    else:
+        browser_name = "chromium"
+
+    collaborate(playwright, browser_name)

--- a/nextcloud/nextcloud_install.py
+++ b/nextcloud/nextcloud_install.py
@@ -1,0 +1,56 @@
+import sys
+from time import time_ns
+
+from playwright.sync_api import sync_playwright, Error
+
+def log_note(message: str) -> None:
+    timestamp = str(time_ns())[:16]
+    print(f"{timestamp} {message}")
+
+def main(browser_name: str = "chromium"):
+    with sync_playwright() as playwright:
+        log_note(f"Launch browser {browser_name}")
+        if browser_name == "firefox":
+            browser_type = playwright.firefox
+        else:
+            browser_type = playwright.chromium
+        browser = browser_type.launch(headless=True)
+        context = browser.new_context()
+        page = context.new_page()
+        try:
+            page.goto('http://nc/')
+            page.set_default_timeout(180_000)
+
+            # 1. Create User
+            log_note("Create admin user")
+            page.type('#adminlogin', 'Crash')
+            page.type('#adminpass', 'Override')
+            page.click('.primary')
+
+            # 2. Install all Apps
+            log_note("Install recommended apps")
+            install_selector = '.button-vue--vue-primary'
+            page.wait_for_selector(install_selector)
+            page.click(install_selector)
+
+            # 3. Dashboard
+            page.wait_for_selector('.app-dashboard')
+            log_note("Installation complete")
+            browser.close()
+
+        except Error as e:
+            log_note(f"Exception occurred: {e.message}")
+            log_note(f"Page content was: {page.content()}")
+            raise e
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        browser_name = sys.argv[1].lower()
+        if browser_name not in ["chromium", "firefox"]:
+            print("Invalid browser name. Please choose either 'chromium' or 'firefox'.")
+            sys.exit(1)
+    else:
+        browser_name = "chromium"
+
+    main(browser_name)

--- a/nextcloud/nextcloud_install.py
+++ b/nextcloud/nextcloud_install.py
@@ -19,7 +19,7 @@ def main(browser_name: str = "chromium"):
         page = context.new_page()
         try:
             page.goto('http://nc/')
-            page.set_default_timeout(180_000)
+            page.set_default_timeout(240_000)
 
             # 1. Create User
             log_note("Create admin user")

--- a/nextcloud/nextcloud_talk.py
+++ b/nextcloud/nextcloud_talk.py
@@ -1,0 +1,162 @@
+import contextlib
+import random
+import string
+import sys
+from time import sleep, time_ns
+
+from playwright.sync_api import Playwright, sync_playwright, expect, Error
+
+def log_note(message: str) -> None:
+    timestamp = str(time_ns())[:16]
+    print(f"{timestamp} {message}")
+
+def get_random_text() -> str:
+    size_in_bytes = 20 * 1024
+    characters = string.ascii_letters + string.digits
+    return ''.join(random.choice(characters) for _ in range(size_in_bytes))
+
+def send_message(sender, message):
+    log_note("Sending message")
+    sender.get_by_role("textbox", name="Write message, @ to mention someone …").click()
+    sender.get_by_role("textbox", name="Write message, @ to mention someone …").fill(message)
+    sender.get_by_role("textbox", name="Write message, @ to mention someone …").press("Enter")
+
+def create_conversation(playwright: Playwright, browser_name: str) -> str:
+    headless = True
+    log_note(f"Launch browser {browser_name}")
+    if browser_name == "firefox":
+        browser = playwright.firefox.launch(headless=headless)
+    else:
+        browser = playwright.chromium.launch(headless=headless)
+    context = browser.new_context()
+    page = context.new_page()
+    try:
+        log_note("Login as admin")
+        page.goto("http://nc/")
+        page.get_by_label("Account name or email").click()
+        page.get_by_label("Account name or email").fill("Crash")
+        page.get_by_label("Account name or email").press("Tab")
+        page.get_by_label("Password", exact=True).fill("Override")
+        page.get_by_role("button", name="Log in").click()
+
+        # Wait for the modal to load. As it seems you can't close it while it is showing the opening animation.
+        log_note("Close first-time run popup")
+        with contextlib.suppress(Exception):
+            sleep(5)
+            page.get_by_role("button", name="Close modal").click(timeout=15_000)
+
+        log_note("Open Talk app")
+        page.get_by_role("link", name="Talk", exact=True).click()
+        page.wait_for_url("**/apps/spreed/")
+
+        # Second welcome screen?
+        with contextlib.suppress(Exception):
+            page.get_by_role("button", name="Close modal").click(timeout=15_000)
+
+        # Headless browsers trigger a warning in Nextcloud, however they actually work fine
+        if headless:
+            log_note("Close headless warning")
+            with contextlib.suppress(Exception):
+                page.wait_for_selector('.toast-close')
+                page.click('.toast-close')
+
+                page.wait_for_selector('.toast-close')
+                page.click('.toast-close')
+
+        log_note("Create conversation")
+        page.get_by_role("button", name="Create a new group conversation").click()
+        page.get_by_placeholder("Enter a name for this conversation").fill("Random talk")
+        page.get_by_text("Allow guests to join via link").click()
+        page.get_by_role("button", name="Create conversation").click()
+        page.get_by_role("button", name="Copy conversation link").click()
+        log_note("Close browser")
+
+        # ---------------------
+        page.close()
+        context.close()
+        browser.close()
+
+        return page.url
+
+    except Error as e:
+        log_note(f"Exception occurred: {e.message}")
+        log_note(f"Page content was: {page.content()}")
+        raise e
+
+def talk(playwright: Playwright, url: str, browser_name: str) -> None:
+    headless = True
+    action_delay_ms = 300
+    browser_count = 5
+
+    # Launch browsers
+    log_note(f"Launching {browser_count} {browser_name} browsers")
+    if browser_name == "firefox":
+        browsers = [playwright.firefox.launch(headless=headless, slow_mo=action_delay_ms) for _ in range(browser_count)]
+    else:
+        browsers = [playwright.chromium.launch(headless=headless, slow_mo=action_delay_ms) for _ in range(browser_count)]
+    contexts = [browser.new_context() for browser in browsers]
+    pages = [context.new_page() for context in contexts]
+
+    # Go to URL for all users
+    log_note("Navigating to Talk conversation")
+    for page in pages:
+        page.goto(url)
+
+    # Close toast messages for headless browsers
+    if headless:
+        log_note("Close headless warning")
+        with contextlib.suppress(Exception):
+            for page in pages:
+                page.wait_for_selector('.toast-close').click()
+
+    # Perform actions for all users
+    log_note("Set guest usernames")
+    for page in pages:
+        page.get_by_role("button", name="Edit").click()
+        page.get_by_placeholder("Guest").fill(f"Dude#{pages.index(page) + 1}")
+        page.get_by_role("button", name="Save name").click()
+
+    # Send first message and check for visibility
+    log_note("Send the first validation message")
+    sender = pages[0]
+    message = "Let's send some random text!"
+    send_message(sender, message)
+    log_note("Validate the first message got received")
+    for page in pages[1:]:
+        expect(page.get_by_text(message, exact=True)).to_be_visible()
+
+    # Send random text and validate it was received by other users
+    log_note("Start sending random messages")
+    for i, sender in enumerate(pages):
+        receivers = pages[:i] + pages[i + 1:]
+        random_text = get_random_text()
+
+        send_message(sender, random_text)
+        for receiver in receivers:
+            expect(receiver.get_by_text(random_text, exact=True)).to_be_visible()
+        log_note("Message received by all users")
+
+    # --------------------
+    # Close all users
+    log_note("Close all browsers")
+    for page in pages:
+        page.close()
+
+    for context in contexts:
+        context.close()
+
+    for browser in browsers:
+        browser.close()
+
+
+with sync_playwright() as playwright:
+    if len(sys.argv) > 1:
+        browser_name = sys.argv[1].lower()
+        if browser_name not in ["chromium", "firefox"]:
+            print("Invalid browser name. Please choose either 'chromium' or 'firefox'.")
+            sys.exit(1)
+    else:
+        browser_name = "chromium"
+
+    conversation_link = create_conversation(playwright, browser_name)
+    talk(playwright, conversation_link, browser_name)

--- a/nextcloud/nextcloud_talk.py
+++ b/nextcloud/nextcloud_talk.py
@@ -65,7 +65,8 @@ def create_conversation(playwright: Playwright, browser_name: str) -> str:
 
         log_note("Create conversation")
         page.get_by_role("button", name="Create a new group conversation").click()
-        page.get_by_placeholder("Enter a name for this conversation").fill("Random talk")
+        # Different placeholder names and capitalization on apache vs FPM
+        page.get_by_placeholder("name").fill("Random talk")
         page.get_by_text("Allow guests to join via link").click()
         page.get_by_role("button", name="Create conversation").click()
         page.get_by_role("button", name="Copy conversation link").click()

--- a/nextcloud/nginx.conf
+++ b/nextcloud/nginx.conf
@@ -1,0 +1,173 @@
+worker_processes auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    # Prevent nginx HTTP Server Detection
+    server_tokens   off;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    upstream php-handler {
+        server app:9000;
+    }
+
+    server {
+        listen 80;
+
+        # HSTS settings
+        # WARNING: Only add the preload option once you read about
+        # the consequences in https://hstspreload.org/. This option
+        # will add the domain to a hardcoded list that is shipped
+        # in all major browsers and getting removed from this list
+        # could take several months.
+        #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
+
+        # set max upload size
+        client_max_body_size 512M;
+        fastcgi_buffers 64 4K;
+
+        # Enable gzip but do not remove ETag headers
+        gzip on;
+        gzip_vary on;
+        gzip_comp_level 4;
+        gzip_min_length 256;
+        gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
+        gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+
+        # Pagespeed is not supported by Nextcloud, so if your server is built
+        # with the `ngx_pagespeed` module, uncomment this line to disable it.
+        #pagespeed off;
+
+        # HTTP response headers borrowed from Nextcloud `.htaccess`
+        add_header Referrer-Policy                      "no-referrer"   always;
+        add_header X-Content-Type-Options               "nosniff"       always;
+        add_header X-Download-Options                   "noopen"        always;
+        add_header X-Frame-Options                      "SAMEORIGIN"    always;
+        add_header X-Permitted-Cross-Domain-Policies    "none"          always;
+        add_header X-Robots-Tag                         "none"          always;
+        add_header X-XSS-Protection                     "1; mode=block" always;
+
+        # Remove X-Powered-By, which is an information leak
+        fastcgi_hide_header X-Powered-By;
+
+        # Path to the root of your installation
+        root /var/www/html;
+
+        # Specify how to handle directories -- specifying `/index.php$request_uri`
+        # here as the fallback means that Nginx always exhibits the desired behaviour
+        # when a client requests a path that corresponds to a directory that exists
+        # on the server. In particular, if that directory contains an index.php file,
+        # that file is correctly served; if it doesn't, then the request is passed to
+        # the front-end controller. This consistent behaviour means that we don't need
+        # to specify custom rules for certain paths (e.g. images and other assets,
+        # `/updater`, `/ocm-provider`, `/ocs-provider`), and thus
+        # `try_files $uri $uri/ /index.php$request_uri`
+        # always provides the desired behaviour.
+        index index.php index.html /index.php$request_uri;
+
+        # Rule borrowed from `.htaccess` to handle Microsoft DAV clients
+        location = / {
+            if ( $http_user_agent ~ ^DavClnt ) {
+                return 302 /remote.php/webdav/$is_args$args;
+            }
+        }
+
+        location = /robots.txt {
+            allow all;
+            log_not_found off;
+            access_log off;
+        }
+
+        # Make a regex exception for `/.well-known` so that clients can still
+        # access it despite the existence of the regex rule
+        # `location ~ /(\.|autotest|...)` which would otherwise handle requests
+        # for `/.well-known`.
+        location ^~ /.well-known {
+            # The rules in this block are an adaptation of the rules
+            # in `.htaccess` that concern `/.well-known`.
+
+            location = /.well-known/carddav { return 301 /remote.php/dav/; }
+            location = /.well-known/caldav  { return 301 /remote.php/dav/; }
+
+            location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
+            location /.well-known/pki-validation    { try_files $uri $uri/ =404; }
+
+            # Let Nextcloud's API for `/.well-known` URIs handle all other
+            # requests by passing them to the front-end controller.
+            return 301 /index.php$request_uri;
+        }
+
+        # Rules borrowed from `.htaccess` to hide certain paths from clients
+        location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)  { return 404; }
+        location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console)                { return 404; }
+
+        # Ensure this block, which passes PHP files to the PHP process, is above the blocks
+        # which handle static assets (as seen below). If this block is not declared first,
+        # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
+        # to the URI, resulting in a HTTP 500 error response.
+        location ~ \.php(?:$|/) {
+            # Required for legacy support
+            rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
+
+            fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+            set $path_info $fastcgi_path_info;
+
+            try_files $fastcgi_script_name =404;
+
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param PATH_INFO $path_info;
+            #fastcgi_param HTTPS on;
+
+            fastcgi_param modHeadersAvailable true;         # Avoid sending the security headers twice
+            fastcgi_param front_controller_active true;     # Enable pretty urls
+            fastcgi_pass php-handler;
+
+            fastcgi_intercept_errors on;
+            fastcgi_request_buffering off;
+        }
+
+        location ~ \.(?:css|js|svg|gif)$ {
+            try_files $uri /index.php$request_uri;
+            expires 6M;         # Cache-Control policy borrowed from `.htaccess`
+            access_log off;     # Optional: Don't log access to assets
+        }
+
+        location ~ \.woff2?$ {
+            try_files $uri /index.php$request_uri;
+            expires 7d;         # Cache-Control policy borrowed from `.htaccess`
+            access_log off;     # Optional: Don't log access to assets
+        }
+
+        # Rule borrowed from `.htaccess`
+        location /remote {
+            return 301 /remote.php$request_uri;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.php$request_uri;
+        }
+    }
+}

--- a/nextcloud/usage_scenario-fpm-mariadb-event-chromium.yml
+++ b/nextcloud/usage_scenario-fpm-mariadb-event-chromium.yml
@@ -1,0 +1,57 @@
+---
+name: Nextcloud - MariaDB - Event - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud FPM image with a MariaDB and creates a calendar event. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create an event.
+compose-file: !include compose-fpm-mariadb.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_event.py /tmp/nextcloud_create_event.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  app:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Login and create event
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_event.py
+        note: Creating event
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-fpm-mariadb-talk-chromium.yml
+++ b/nextcloud/usage_scenario-fpm-mariadb-talk-chromium.yml
@@ -1,7 +1,7 @@
 ---
-name: Nextcloud - FPM - MariaDB - Event - Chromium
+name: Nextcloud - FPM - MariaDB - Talk - Chromium
 author: Danilo Jesic <danilo@green-coding.berlin>
-description: Installs the official Nextcloud FPM image with a MariaDB and creates a calendar event. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create an event.
+description: Installs the official Nextcloud FPM image with a MariaDB and starts a Talk conversation. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create a Talk conversation where guest users will send each other random text.
 compose-file: !include compose-fpm-mariadb.yml
 
 services:
@@ -9,7 +9,7 @@ services:
     image: greencoding/gcb_playwright
     setup-commands:
       - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
-      - cp /tmp/repo/nextcloud_create_event.py /tmp/nextcloud_create_event.py
+      - cp /tmp/repo/nextcloud_talk.py /tmp/nextcloud_talk.py
 
     networks:
       - nextcloud-setup-network
@@ -46,12 +46,12 @@ flow:
         read-notes-stdout: true
         log-stdout: true
         log-stderr: true
-  - name: Login and create event
+  - name: Talk conversation
     container: gcb-playwright
     commands:
       - type: console
-        command: python3 /tmp/nextcloud_create_event.py
-        note: Creating event
+        command: python3 /tmp/nextcloud_talk.py
+        note: Starting conversation
         read-notes-stdout: true
         log-stdout: true
         log-stderr: true

--- a/nextcloud/usage_scenario-mariadb-docs-chromium.yml
+++ b/nextcloud/usage_scenario-mariadb-docs-chromium.yml
@@ -1,0 +1,73 @@
+---
+name: Nextcloud - MariaDB - Docs - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a MariaDB and collaborates on a document. Uses a playwright script running Chromium to create an admin account, install the recommended apps. Then creates a new user, creates a document and shares it. Finally, works on the document adding text from two browsers.
+compose-file: !include compose-mariadb.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_user.py /tmp/nextcloud_create_user.py
+      - cp /tmp/repo/nextcloud_create_doc_and_share.py /tmp/nextcloud_create_doc_and_share.py
+      - cp /tmp/repo/nextcloud_docs_collaboration.py /tmp/nextcloud_docs_collaboration.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create User
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_user.py
+        note: Create user
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create doc and share
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_doc_and_share.py
+        note: Create document and share
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Collaborate
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_docs_collaboration.py
+        note: dev
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-mariadb-docs-firefox.yml
+++ b/nextcloud/usage_scenario-mariadb-docs-firefox.yml
@@ -1,0 +1,73 @@
+---
+name: Nextcloud - MariaDB - Docs - Firefox
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a MariaDB and collaborates on a document. Uses a playwright script running Firefox to create an admin account, install the recommended apps. Then creates a new user, creates a document and shares it. Finally, works on the document adding text from two browsers.
+compose-file: !include compose-mariadb.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_user.py /tmp/nextcloud_create_user.py
+      - cp /tmp/repo/nextcloud_create_doc_and_share.py /tmp/nextcloud_create_doc_and_share.py
+      - cp /tmp/repo/nextcloud_docs_collaboration.py /tmp/nextcloud_docs_collaboration.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py firefox
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create User
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_user.py firefox
+        note: Create user
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create doc and share
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_doc_and_share.py firefox
+        note: Create document and share
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Collaborate
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_docs_collaboration.py firefox
+        note: dev
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-mariadb-event-chromium.yml
+++ b/nextcloud/usage_scenario-mariadb-event-chromium.yml
@@ -1,0 +1,53 @@
+---
+name: Nextcloud - MariaDB - Event - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a MariaDB and creates a calendar event. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create an event.
+compose-file: !include compose-mariadb.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_event.py /tmp/nextcloud_create_event.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Login and create event
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_event.py
+        note: Creating event
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-mariadb-event-firefox.yml
+++ b/nextcloud/usage_scenario-mariadb-event-firefox.yml
@@ -1,0 +1,54 @@
+---
+name: Nextcloud - MariaDB - Event - Firefox
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a MariaDB and creates a calendar event. Uses a playwright script running Firefox to create an admin account, install the recommended apps and then create an event.
+compose-file: !include compose-mariadb.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_event.py /tmp/nextcloud_create_event.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py firefox
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+
+  - name: Login and create event
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_event.py firefox
+        note: Creating event
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-mariadb-talk-chromium.yml
+++ b/nextcloud/usage_scenario-mariadb-talk-chromium.yml
@@ -1,0 +1,53 @@
+---
+name: Nextcloud - MariaDB - Talk - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a MariaDB and starts a Talk conversation. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create a Talk conversation where guest users will send each other random text.
+compose-file: !include compose-mariadb.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_talk.py /tmp/nextcloud_talk.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Talk conversation
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_talk.py
+        note: Starting conversation
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-mariadb-talk-firefox.yml
+++ b/nextcloud/usage_scenario-mariadb-talk-firefox.yml
@@ -1,0 +1,53 @@
+---
+name: Nextcloud - MariaDB - Talk - Firefox
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a MariaDB and starts a Talk conversation. Uses a playwright script running Firefox to create an admin account, install the recommended apps and then create a Talk conversation where guest users will send each other random text.
+compose-file: !include compose-mariadb.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_talk.py /tmp/nextcloud_talk.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py firefox
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Talk conversation
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_talk.py firefox
+        note: Starting conversation
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-postgres-docs-chromium.yml
+++ b/nextcloud/usage_scenario-postgres-docs-chromium.yml
@@ -1,0 +1,73 @@
+---
+name: Nextcloud - Postgres - Docs - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a Postgres and collaborates on a document. Uses a playwright script running Chromium to create an admin account, install the recommended apps. Then creates a new user, creates a document and shares it. Finally, works on the document adding text from two browsers.
+compose-file: !include compose-postgres.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_user.py /tmp/nextcloud_create_user.py
+      - cp /tmp/repo/nextcloud_create_doc_and_share.py /tmp/nextcloud_create_doc_and_share.py
+      - cp /tmp/repo/nextcloud_docs_collaboration.py /tmp/nextcloud_docs_collaboration.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create User
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_user.py
+        note: Create user
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create doc and share
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_doc_and_share.py
+        note: Create document and share
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Collaborate
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_docs_collaboration.py
+        note: dev
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-postgres-docs-firefox.yml
+++ b/nextcloud/usage_scenario-postgres-docs-firefox.yml
@@ -1,0 +1,73 @@
+---
+name: Nextcloud - Postgres - Docs - Firefox
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a Postgres and collaborates on a document. Uses a playwright script running Firefox to create an admin account, install the recommended apps. Then creates a new user, creates a document and shares it. Finally, works on the document adding text from two browsers.
+compose-file: !include compose-postgres.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_user.py /tmp/nextcloud_create_user.py
+      - cp /tmp/repo/nextcloud_create_doc_and_share.py /tmp/nextcloud_create_doc_and_share.py
+      - cp /tmp/repo/nextcloud_docs_collaboration.py /tmp/nextcloud_docs_collaboration.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py firefox
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create User
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_user.py firefox
+        note: Create user
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create doc and share
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_doc_and_share.py firefox
+        note: Create document and share
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Collaborate
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_docs_collaboration.py firefox
+        note: dev
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-postgres-event-chromium.yml
+++ b/nextcloud/usage_scenario-postgres-event-chromium.yml
@@ -1,0 +1,54 @@
+---
+name: Nextcloud - Postgres - Event - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+version: 1
+description: Installs the official Nextcloud image with a Postgres DB and creates a calendar event. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create a calendar event.
+compose-file: !include compose-postgres.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_event.py /tmp/nextcloud_create_event.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Login and create event
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_event.py
+        note: Creating event
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-postgres-event-firefox.yml
+++ b/nextcloud/usage_scenario-postgres-event-firefox.yml
@@ -1,0 +1,54 @@
+---
+name: Nextcloud - Postgres - Event - Firefox
+author: Danilo Jesic <danilo@green-coding.berlin>
+version: 1
+description: Installs the official Nextcloud image with a Postgres DB and creates a calendar event. Uses a playwright script running Firefox to create an admin account, install the recommended apps and then create a calendar event.
+compose-file: !include compose-postgres.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_event.py /tmp/nextcloud_create_event.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py firefox
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Login and create event
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_event.py firefox
+        note: Creating event
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-postgres-talk-chromium.yml
+++ b/nextcloud/usage_scenario-postgres-talk-chromium.yml
@@ -1,0 +1,53 @@
+---
+name: Nextcloud - Postgres - Talk - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a Postgres and starts a Talk conversation. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create a Talk conversation where guest users will send each other random text.
+compose-file: !include compose-postgres.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_talk.py /tmp/nextcloud_talk.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Talk conversation
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_talk.py
+        note: Starting conversation
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-postgres-talk-firefox.yml
+++ b/nextcloud/usage_scenario-postgres-talk-firefox.yml
@@ -1,0 +1,53 @@
+---
+name: Nextcloud - Postgres - Talk - Firefox
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a Postgres and starts a Talk conversation. Uses a playwright script running Firefox to create an admin account, install the recommended apps and then create a Talk conversation where guest users will send each other random text.
+compose-file: !include compose-postgres.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_talk.py /tmp/nextcloud_talk.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+  db:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py firefox
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Talk conversation
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_talk.py firefox
+        note: Starting conversation
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-sqlite-docs-chromium.yml
+++ b/nextcloud/usage_scenario-sqlite-docs-chromium.yml
@@ -1,0 +1,69 @@
+---
+name: Nextcloud - SQLite - Docs - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a SQLite and collaborates on a document. Uses a playwright script running Chromium to create an admin account, install the recommended apps. Then creates a new user, creates a document and shares it. Finally, works on the document adding text from two browsers.
+compose-file: !include compose-sqlite.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_user.py /tmp/nextcloud_create_user.py
+      - cp /tmp/repo/nextcloud_create_doc_and_share.py /tmp/nextcloud_create_doc_and_share.py
+      - cp /tmp/repo/nextcloud_docs_collaboration.py /tmp/nextcloud_docs_collaboration.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create User
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_user.py
+        note: Create user
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create doc and share
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_doc_and_share.py
+        note: Create document and share
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Collaborate
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_docs_collaboration.py
+        note: dev
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-sqlite-docs-firefox.yml
+++ b/nextcloud/usage_scenario-sqlite-docs-firefox.yml
@@ -1,0 +1,69 @@
+---
+name: Nextcloud - SQLite - Docs - Firefox
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a SQLite and collaborates on a document. Uses a playwright script running Firefox to create an admin account, install the recommended apps. Then creates a new user, creates a document and shares it. Finally, works on the document adding text from two browsers.
+compose-file: !include compose-sqlite.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_user.py /tmp/nextcloud_create_user.py
+      - cp /tmp/repo/nextcloud_create_doc_and_share.py /tmp/nextcloud_create_doc_and_share.py
+      - cp /tmp/repo/nextcloud_docs_collaboration.py /tmp/nextcloud_docs_collaboration.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py firefox
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create User
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_user.py firefox
+        note: Create user
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Create doc and share
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_doc_and_share.py firefox
+        note: Create document and share
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Collaborate
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_docs_collaboration.py firefox
+        note: dev
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-sqlite-event-chromium.yml
+++ b/nextcloud/usage_scenario-sqlite-event-chromium.yml
@@ -1,0 +1,49 @@
+---
+name: Nextcloud - SQLite - Event - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a SQLite and creates a calendar event. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create an event.
+compose-file: !include compose-sqlite.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_event.py /tmp/nextcloud_create_event.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Login and create event
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_event.py
+        note: Creating event
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-sqlite-event-firefox.yml
+++ b/nextcloud/usage_scenario-sqlite-event-firefox.yml
@@ -1,0 +1,49 @@
+---
+name: Nextcloud - SQLite - Event - Firefox
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a SQLite and creates a calendar event. Uses a playwright script running Firefox to create an admin account, install the recommended apps and then create an event.
+compose-file: !include compose-sqlite.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_create_event.py /tmp/nextcloud_create_event.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py firefox
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Login and create event
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_create_event.py firefox
+        note: Creating event
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-sqlite-talk-chromium.yml
+++ b/nextcloud/usage_scenario-sqlite-talk-chromium.yml
@@ -2,7 +2,7 @@
 name: Nextcloud - SQLite - Talk - Chromium
 author: Danilo Jesic <danilo@green-coding.berlin>
 description: Installs the official Nextcloud image with a SQLite and starts a Talk conversation. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create a Talk conversation where guest users will send each other random text.
-compose-file: !include compose-mariadb.yml
+compose-file: !include compose-sqlite.yml
 
 services:
   gcb-playwright:

--- a/nextcloud/usage_scenario-sqlite-talk-chromium.yml
+++ b/nextcloud/usage_scenario-sqlite-talk-chromium.yml
@@ -1,0 +1,49 @@
+---
+name: Nextcloud - SQLite - Talk - Chromium
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a SQLite and starts a Talk conversation. Uses a playwright script running Chromium to create an admin account, install the recommended apps and then create a Talk conversation where guest users will send each other random text.
+compose-file: !include compose-mariadb.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_talk.py /tmp/nextcloud_talk.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Talk conversation
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_talk.py
+        note: Starting conversation
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true

--- a/nextcloud/usage_scenario-sqlite-talk-firefox.yml
+++ b/nextcloud/usage_scenario-sqlite-talk-firefox.yml
@@ -2,7 +2,7 @@
 name: Nextcloud - SQLite - Talk - Firefox
 author: Danilo Jesic <danilo@green-coding.berlin>
 description: Installs the official Nextcloud image with a SQLite and starts a Talk conversation. Uses a playwright script running Firefox to create an admin account, install the recommended apps and then create a Talk conversation where guest users will send each other random text.
-compose-file: !include compose-mariadb.yml
+compose-file: !include compose-sqlite.yml
 
 services:
   gcb-playwright:

--- a/nextcloud/usage_scenario-sqlite-talk-firefox.yml
+++ b/nextcloud/usage_scenario-sqlite-talk-firefox.yml
@@ -1,0 +1,49 @@
+---
+name: Nextcloud - SQLite - Talk - Firefox
+author: Danilo Jesic <danilo@green-coding.berlin>
+description: Installs the official Nextcloud image with a SQLite and starts a Talk conversation. Uses a playwright script running Firefox to create an admin account, install the recommended apps and then create a Talk conversation where guest users will send each other random text.
+compose-file: !include compose-mariadb.yml
+
+services:
+  gcb-playwright:
+    image: greencoding/gcb_playwright
+    setup-commands:
+      - cp /tmp/repo/nextcloud_install.py /tmp/nextcloud_install.py
+      - cp /tmp/repo/nextcloud_talk.py /tmp/nextcloud_talk.py
+
+    networks:
+      - nextcloud-setup-network
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix
+    # environment:
+    #   DISPLAY: ":0"
+
+  # We don't need the volumes are we don't want to persist any data
+
+  nc:
+    volumes: []
+    networks:
+      - nextcloud-setup-network
+
+networks:
+  nextcloud-setup-network:
+
+flow:
+  - name: Install Nextcloud
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_install.py firefox
+        note: Installing Nextcloud
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true
+  - name: Talk conversation
+    container: gcb-playwright
+    commands:
+      - type: console
+        command: python3 /tmp/nextcloud_talk.py firefox
+        note: Starting conversation
+        read-notes-stdout: true
+        log-stdout: true
+        log-stderr: true


### PR DESCRIPTION
Three cases, two browsers, three databases - all combinations under `nextcloud:27.0.0-apache`
Just two cases for FPM, see note

Notes:

- The install script sometimes takes more than 180s on my machine depending on internet, I've bumped the timeout to 240s. 
- Firefox scenarios happen to timeout more often on my machine, particularly in Talk and Docs cases - the assertion to validate a received message timesout. Could be machine specific, or the timeout could be increased?
- FPM: I've only pushed the Event and Docs cases, I've tried to adapt the Talk case but I have noticed in the first two cases  that the UI looks different (more like 26.3 than 27.0) and matching an input field is different between Apache and FPM. I have a gut feeling that `nextcloud:27.0.0-fpm` image is wrong and contains 26.3 instead
- Many usage scenario files - I don't see an obvious way to simplify this duplication, any suggestions?
- Logs: Crashed runs produce very large log files, as page content is dumped. It was useful in debugging, but just mentioning it again for the sake of a potential disk space issues. The log files are significantly smaller when the scenario fails during installation, and those I've seen more often. Hopefully, we'll only be seeing green runs :)
