### PR TITLE
Add JMeter example application

### DIFF
--- a/jmeter/README.md
+++ b/jmeter/README.md
@@ -12,10 +12,10 @@ As an example web application the reference application [T2-Project](https://t2-
 JMeter gets executed as part of the flow in `usage_scenario.yml` with the following command:
 
 ```bash
-jmeter -Jhostname=gcb-backend -Jport=8080 -JnumExecutions=1 -JnumUser=1 -JrampUp=0 -JnumProducts=1 -JthinkTimeMin=0 -JthinkTimeAdditionalRange=0 -JtimeBetweenExecutions=0 -JloggingEnabled=true -n -t /tmp/repo/jmeter-test-plan.jmx
+jmeter -Jhostname=gcb-backend -Jport=8080 -JnumExecutions=1 -JnumUser=1 -JrampUp=0 -JnumProducts=1 -JthinkTimeMin=0 -JthinkTimeAdditionalRange=0 -JpauseBeforeExecution=0 -JpauseAfterExecution=0 -JloggingEnabled=true -n -t /tmp/repo/jmeter-test-plan.jmx
 ```
 
-`hostname`, `port`, `numExecutions`, `numUser`, `rampUp`, `numProducts`, `thinkTimeMin`, `thinkTimeAdditionalRange`, `timeBetweenExecutions` and `loggingEnabled` are environment variables that get passed to JMeter. They are specific for this test plan (`jmeter-test-plan.jmx`).
+`hostname`, `port`, `numExecutions`, `numUser`, `rampUp`, `numProducts`, `thinkTimeMin`, `thinkTimeAdditionalRange`, `pauseBeforeExecution`, `pauseAfterExecution` and `loggingEnabled` are environment variables that get passed to JMeter. They are specific for this test plan (`jmeter-test-plan.jmx`).
 If you want to understand this test plan you can use the JMeter GUI and open the file `jmeter-test-plan.jmx`.
 
 ## Running the measurement

--- a/jmeter/README.md
+++ b/jmeter/README.md
@@ -1,0 +1,23 @@
+# JMeter
+
+[Apache JMeter](https://jmeter.apache.org/) is a load and performance testing tool.
+This example demonstrates how to use JMeter to execute a test plan that makes HTTP requests to a web application.
+
+It is based on a customized [JMeter Docker image](https://hub.docker.com/r/t2project/jmeter).
+
+As an example web application the reference application [T2-Project](https://t2-documentation.readthedocs.io) is used.
+
+## JMeter Execution
+
+JMeter gets executed as part of the flow in `usage_scenario.yml` with the following command:
+
+```bash
+jmeter -Jhostname=gcb-backend -Jport=8080 -JnumExecutions=1 -JnumUser=1 -JrampUp=0 -JnumProducts=1 -JthinkTimeMin=0 -JthinkTimeAdditionalRange=0 -JtimeBetweenExecutions=0 -JloggingEnabled=true -n -t /tmp/repo/jmeter-test-plan.jmx
+```
+
+`hostname`, `port`, `numExecutions`, `numUser`, `rampUp`, `numProducts`, `thinkTimeMin`, `thinkTimeAdditionalRange`, `timeBetweenExecutions` and `loggingEnabled` are environment variables that get passed to JMeter. They are specific for this test plan (`jmeter-test-plan.jmx`).
+If you want to understand this test plan you can use the JMeter GUI and open the file `jmeter-test-plan.jmx`.
+
+## Running the measurement
+
+To check how to run the measurements check out our [Documentation](https://docs.green-coding.berlin)

--- a/jmeter/README.md
+++ b/jmeter/README.md
@@ -21,3 +21,10 @@ If you want to understand this test plan you can use the JMeter GUI and open the
 ## Running the measurement
 
 To check how to run the measurements check out our [Documentation](https://docs.green-coding.berlin)
+
+## OpenEnergyBadge
+
+These badges show the energy cost for running this code on a single machine and the emissions per order (SCI score).
+
+<a href="https://metrics.green-coding.berlin/stats.html?id=207c1ae2-d2b5-4fc9-a6ea-b68c2f69073a"><img src="https://api.green-coding.berlin/v1/badge/single/207c1ae2-d2b5-4fc9-a6ea-b68c2f69073a?metric=RAPL"></a>
+<a href="https://metrics.green-coding.berlin/stats.html?id=207c1ae2-d2b5-4fc9-a6ea-b68c2f69073a"><img src="https://api.green-coding.berlin/v1/badge/single/207c1ae2-d2b5-4fc9-a6ea-b68c2f69073a?metric=SCI"></a>

--- a/jmeter/compose.yml
+++ b/jmeter/compose.yml
@@ -13,7 +13,7 @@ services:
     networks:
       - t2-network
   gcb-backend:
-    image: t2project/modulith:gmt-jmeter-example
+    image: t2project/modulith@sha256:180c620862e6aa936f00245c04fe0510896c2c8059663e3f0fae2a76b7a56966
     depends_on:
       - gcb-postgres
       - gcb-mongo
@@ -24,7 +24,7 @@ services:
     networks:
       - t2-network
   gcb-jmeter:
-    image: t2project/jmeter:5.6.2
+    image: t2project/jmeter@sha256:8d0543345f747ae512da2f0732fbd0ee760c7168415d2dce87e77d42fd14390a
     environment:
       JVM_XMN: 100 # maximum nursery size
       JVM_XMS: 250 # initial heap size

--- a/jmeter/compose.yml
+++ b/jmeter/compose.yml
@@ -1,0 +1,36 @@
+---
+version: "2"
+services:
+  gcb-postgres:
+    image: postgres:15.4
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    networks:
+      - t2-network
+  gcb-mongo:
+    image: mongo:5.0
+    networks:
+      - t2-network
+  gcb-backend:
+    image: t2project/modulith:gmt-jmeter-example
+    depends_on:
+      - gcb-postgres
+      - gcb-mongo
+    environment:
+      MONGO_HOST: gcb-mongo
+      POSTGRES_HOST: gcb-postgres
+      SPRING_PROFILES_ACTIVE: gmt
+    networks:
+      - t2-network
+  gcb-jmeter:
+    image: t2project/jmeter:5.6.2
+    environment:
+      JVM_XMN: 100 # maximum nursery size
+      JVM_XMS: 250 # initial heap size
+      JVM_XMX: 500 # maximum heap size
+    networks:
+      - t2-network
+
+networks:
+  t2-network:

--- a/jmeter/jmeter-test-plan.jmx
+++ b/jmeter/jmeter-test-plan.jmx
@@ -47,14 +47,19 @@
             <stringProp name="Argument.value">${__P(thinkTimeAdditionalRange,0)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
-          <elementProp name="time_between_executions" elementType="Argument">
-            <stringProp name="Argument.name">time_between_executions</stringProp>
-            <stringProp name="Argument.value">${__P(timeBetweenExecutions,0)}</stringProp>
+          <elementProp name="pause_before_execution" elementType="Argument">
+            <stringProp name="Argument.value">${__P(pauseBeforeExecution,0)}</stringProp>
+            <stringProp name="Argument.name">pause_before_execution</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="pause_after_execution" elementType="Argument">
+            <stringProp name="Argument.name">pause_after_execution</stringProp>
+            <stringProp name="Argument.value">${__P(pauseAfterExecution,0)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="logging_enabled" elementType="Argument">
             <stringProp name="Argument.name">logging_enabled</stringProp>
-            <stringProp name="Argument.value">${__P(loggingEnabled,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(loggingEnabled,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -83,83 +88,132 @@
           <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
         </CookieManager>
         <hashTree/>
-        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="SessionId" enabled="true">
-          <stringProp name="TestPlan.comments">fake sessionId</stringProp>
-          <stringProp name="variableName">sessionId</stringProp>
-          <stringProp name="outputFormat">ID_0000000000</stringProp>
-          <stringProp name="minimumValue">1</stringProp>
-          <stringProp name="maximumValue">2147483647</stringProp>
-          <stringProp name="randomSeed">42</stringProp>
-          <boolProp name="perThread">false</boolProp>
-        </RandomVariableConfig>
-        <hashTree/>
-        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Adding Items to Cart" enabled="true">
-          <stringProp name="LoopController.loops">${num_products}</stringProp>
-        </LoopController>
+        <OnceOnlyController guiclass="OnceOnlyControllerGui" testclass="OnceOnlyController" testname="Generate session ID" enabled="true">
+          <stringProp name="TestPlan.comments">Session ID has to be generated only once per user</stringProp>
+        </OnceOnlyController>
         <hashTree>
-          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
+          <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Generate Session ID" enabled="true">
+            <stringProp name="TestPlan.comments">fake sessionId</stringProp>
+            <stringProp name="variableName">sessionId</stringProp>
+            <stringProp name="outputFormat">ID_0000000000</stringProp>
+            <stringProp name="minimumValue">1</stringProp>
+            <stringProp name="maximumValue">2147483647</stringProp>
+            <stringProp name="randomSeed"></stringProp>
+            <boolProp name="perThread">true</boolProp>
+          </RandomVariableConfig>
+          <hashTree/>
+        </hashTree>
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Pause before execution" enabled="true">
+          <boolProp name="IfController.evaluateAll">false</boolProp>
+          <boolProp name="IfController.useExpression">true</boolProp>
+          <stringProp name="IfController.condition">${__groovy(vars.get(&quot;pause_before_execution&quot;).toInteger() &gt; 0 )}</stringProp>
+        </IfController>
+        <hashTree>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging - Pause" enabled="true">
             <boolProp name="IfController.evaluateAll">false</boolProp>
             <boolProp name="IfController.useExpression">true</boolProp>
             <stringProp name="IfController.condition">${logging_enabled}</stringProp>
           </IfController>
           <hashTree>
-            <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG REQUEST" enabled="true">
+            <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG PAUSE" enabled="true">
               <stringProp name="cacheKey">true</stringProp>
               <stringProp name="filename"></stringProp>
               <stringProp name="parameters"></stringProp>
               <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
-def note = &quot;GET inventory&quot;
+def pause = Integer.parseInt(vars.get(&quot;pause_before_execution&quot;))
 
-log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
+if (pause &gt; 0) {
+	log.info(&quot;${currentTimeMicroseconds} pause before execution: ${pause} ms&quot;)
+}
 </stringProp>
               <stringProp name="scriptLanguage">groovy</stringProp>
             </JSR223Sampler>
             <hashTree/>
           </hashTree>
-          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="get inventory" enabled="true">
-            <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
-              <collectionProp name="Arguments.arguments"/>
-            </elementProp>
-            <stringProp name="HTTPSampler.domain">${hostname}</stringProp>
-            <stringProp name="HTTPSampler.port">${port}</stringProp>
-            <stringProp name="HTTPSampler.path">/products</stringProp>
-            <stringProp name="HTTPSampler.method">GET</stringProp>
-            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-            <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
-            <boolProp name="HTTPSampler.image_parser">false</boolProp>
-            <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
-            <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
-            <boolProp name="HTTPSampler.md5">false</boolProp>
-            <intProp name="HTTPSampler.ipSourceType">0</intProp>
-          </HTTPSamplerProxy>
+          <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Pause before execution" enabled="true">
+            <intProp name="ActionProcessor.action">1</intProp>
+            <intProp name="ActionProcessor.target">0</intProp>
+            <stringProp name="ActionProcessor.duration">0</stringProp>
+          </TestAction>
           <hashTree>
-            <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="get product id " enabled="true">
-              <stringProp name="RegexExtractor.useHeaders">false</stringProp>
-              <stringProp name="RegexExtractor.refname">ID</stringProp>
-              <stringProp name="RegexExtractor.regex">&quot;id&quot;:&quot;(.*?)&quot;</stringProp>
-              <stringProp name="RegexExtractor.template">$1$</stringProp>
-              <stringProp name="RegexExtractor.default">foooo</stringProp>
-              <stringProp name="RegexExtractor.match_number">0</stringProp>
-              <stringProp name="TestPlan.comments">seletct a random product id and save it to variable ID</stringProp>
-              <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
-            </RegexExtractor>
+            <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Pause" enabled="true">
+              <stringProp name="ConstantTimer.delay">${pause_before_execution}</stringProp>
+            </ConstantTimer>
             <hashTree/>
           </hashTree>
-          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
-            <boolProp name="IfController.evaluateAll">false</boolProp>
-            <boolProp name="IfController.useExpression">true</boolProp>
-            <stringProp name="IfController.condition">${logging_enabled}</stringProp>
-          </IfController>
+        </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop: add items to cart" enabled="true">
+          <stringProp name="LoopController.loops">${num_products}</stringProp>
+        </LoopController>
+        <hashTree>
+          <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Request: GET inventory" enabled="true"/>
           <hashTree>
-            <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG THINKING" enabled="true">
-              <stringProp name="cacheKey">true</stringProp>
-              <stringProp name="filename"></stringProp>
-              <stringProp name="parameters"></stringProp>
-              <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
+            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging - get inventory" enabled="true">
+              <boolProp name="IfController.evaluateAll">false</boolProp>
+              <boolProp name="IfController.useExpression">true</boolProp>
+              <stringProp name="IfController.condition">${logging_enabled}</stringProp>
+            </IfController>
+            <hashTree>
+              <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG REQUEST" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
+def note = &quot;GET inventory&quot;
+
+log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
+</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223Sampler>
+              <hashTree/>
+            </hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request - get inventory" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${hostname}</stringProp>
+              <stringProp name="HTTPSampler.port">${port}</stringProp>
+              <stringProp name="HTTPSampler.path">/products</stringProp>
+              <stringProp name="HTTPSampler.method">GET</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
+              <boolProp name="HTTPSampler.image_parser">false</boolProp>
+              <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
+              <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
+              <boolProp name="HTTPSampler.md5">false</boolProp>
+              <intProp name="HTTPSampler.ipSourceType">0</intProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="get product id " enabled="true">
+                <stringProp name="RegexExtractor.useHeaders">false</stringProp>
+                <stringProp name="RegexExtractor.refname">ID</stringProp>
+                <stringProp name="RegexExtractor.regex">&quot;id&quot;:&quot;(.*?)&quot;</stringProp>
+                <stringProp name="RegexExtractor.template">$1$</stringProp>
+                <stringProp name="RegexExtractor.default">foooo</stringProp>
+                <stringProp name="RegexExtractor.match_number">0</stringProp>
+                <stringProp name="TestPlan.comments">seletct a random product id and save it to variable ID</stringProp>
+                <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
+              </RegexExtractor>
+              <hashTree/>
+            </hashTree>
+          </hashTree>
+          <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Pause: Think Time" enabled="true"/>
+          <hashTree>
+            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging - think time" enabled="true">
+              <boolProp name="IfController.evaluateAll">false</boolProp>
+              <boolProp name="IfController.useExpression">true</boolProp>
+              <stringProp name="IfController.condition">${logging_enabled}</stringProp>
+            </IfController>
+            <hashTree>
+              <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG THINKING" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
 def minThinkTime = Integer.parseInt(vars.get(&quot;think_time_min&quot;))
 def maxThinkTime = minThinkTime + Integer.parseInt(vars.get(&quot;think_time_additional_range&quot;))
 
@@ -169,24 +223,90 @@ if (minThinkTime == maxThinkTime) {
 	log.info(&quot;${currentTimeMicroseconds} think time ${minThinkTime} - ${maxThinkTime} ms&quot;)
 }
 </stringProp>
-              <stringProp name="scriptLanguage">groovy</stringProp>
-            </JSR223Sampler>
-            <hashTree/>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223Sampler>
+              <hashTree/>
+            </hashTree>
+            <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Pause - Think Time" enabled="true">
+              <intProp name="ActionProcessor.action">1</intProp>
+              <intProp name="ActionProcessor.target">0</intProp>
+              <stringProp name="ActionProcessor.duration">0</stringProp>
+            </TestAction>
+            <hashTree>
+              <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Pause" enabled="true">
+                <stringProp name="ConstantTimer.delay">${think_time_min}</stringProp>
+                <stringProp name="RandomTimer.range">${think_time_additional_range}</stringProp>
+                <stringProp name="TestPlan.comments">Users typically need some amount of time to choose a product</stringProp>
+              </UniformRandomTimer>
+              <hashTree/>
+            </hashTree>
           </hashTree>
-          <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Think Time" enabled="true">
-            <intProp name="ActionProcessor.action">1</intProp>
-            <intProp name="ActionProcessor.target">0</intProp>
-            <stringProp name="ActionProcessor.duration">0</stringProp>
-          </TestAction>
+          <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Request: POST add item to cart" enabled="true"/>
           <hashTree>
-            <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Pause" enabled="true">
-              <stringProp name="ConstantTimer.delay">${think_time_min}</stringProp>
-              <stringProp name="RandomTimer.range">${think_time_additional_range}</stringProp>
-              <stringProp name="TestPlan.comments">Users typically need some amount of time to choose a product</stringProp>
-            </UniformRandomTimer>
-            <hashTree/>
+            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging - add item to cart" enabled="true">
+              <boolProp name="IfController.evaluateAll">false</boolProp>
+              <boolProp name="IfController.useExpression">true</boolProp>
+              <stringProp name="IfController.condition">${logging_enabled}</stringProp>
+            </IfController>
+            <hashTree>
+              <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG REQUEST" enabled="true">
+                <stringProp name="cacheKey">true</stringProp>
+                <stringProp name="filename"></stringProp>
+                <stringProp name="parameters"></stringProp>
+                <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
+def note = &quot;POST add item to cart&quot;
+
+log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
+</stringProp>
+                <stringProp name="scriptLanguage">groovy</stringProp>
+              </JSR223Sampler>
+              <hashTree/>
+            </hashTree>
+            <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="add item to cart" enabled="true">
+              <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+              <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                <collectionProp name="Arguments.arguments">
+                  <elementProp name="" elementType="HTTPArgument">
+                    <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                    <stringProp name="Argument.value">{&quot;content&quot; : { &quot;${ID}&quot; : ${__Random(1,5)}}}&#xd;
+&#xd;
+</stringProp>
+                    <stringProp name="Argument.metadata">=</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </elementProp>
+              <stringProp name="HTTPSampler.domain">${hostname}</stringProp>
+              <stringProp name="HTTPSampler.port">${port}</stringProp>
+              <stringProp name="HTTPSampler.path">cart/${sessionId}</stringProp>
+              <stringProp name="HTTPSampler.method">POST</stringProp>
+              <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+              <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+              <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+              <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+              <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
+              <boolProp name="HTTPSampler.image_parser">false</boolProp>
+              <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
+              <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
+              <boolProp name="HTTPSampler.md5">false</boolProp>
+              <intProp name="HTTPSampler.ipSourceType">0</intProp>
+              <stringProp name="TestPlan.comments">add random number of items (1 to 5) of the previously selected product </stringProp>
+            </HTTPSamplerProxy>
+            <hashTree>
+              <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+                <collectionProp name="HeaderManager.headers">
+                  <elementProp name="" elementType="Header">
+                    <stringProp name="Header.name">Content-Type</stringProp>
+                    <stringProp name="Header.value">application/json</stringProp>
+                  </elementProp>
+                </collectionProp>
+              </HeaderManager>
+              <hashTree/>
+            </hashTree>
           </hashTree>
-          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
+        </hashTree>
+        <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Request: confirm order" enabled="true"/>
+        <hashTree>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging - confirm order" enabled="true">
             <boolProp name="IfController.evaluateAll">false</boolProp>
             <boolProp name="IfController.useExpression">true</boolProp>
             <stringProp name="IfController.condition">${logging_enabled}</stringProp>
@@ -197,7 +317,7 @@ if (minThinkTime == maxThinkTime) {
               <stringProp name="filename"></stringProp>
               <stringProp name="parameters"></stringProp>
               <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
-def note = &quot;POST add item to cart&quot;
+def note = &quot;POST confirm order&quot;
 
 log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
 </stringProp>
@@ -205,22 +325,20 @@ log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
             </JSR223Sampler>
             <hashTree/>
           </hashTree>
-          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="add item to cart" enabled="true">
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="confirm order" enabled="true">
             <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
             <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
               <collectionProp name="Arguments.arguments">
                 <elementProp name="" elementType="HTTPArgument">
                   <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">{&quot;content&quot; : { &quot;${ID}&quot; : ${__Random(1,5)}}}&#xd;
-&#xd;
-</stringProp>
+                  <stringProp name="Argument.value">{&quot;cardNumber&quot;:&quot;cardNumber&quot;,&quot;cardOwner&quot;:&quot;cardOwner&quot;,&quot;checksum&quot;:&quot;checksum&quot;, &quot;sessionId&quot;:&quot;${sessionId}&quot;}</stringProp>
                   <stringProp name="Argument.metadata">=</stringProp>
                 </elementProp>
               </collectionProp>
             </elementProp>
             <stringProp name="HTTPSampler.domain">${hostname}</stringProp>
             <stringProp name="HTTPSampler.port">${port}</stringProp>
-            <stringProp name="HTTPSampler.path">cart/${sessionId}</stringProp>
+            <stringProp name="HTTPSampler.path">confirm</stringProp>
             <stringProp name="HTTPSampler.method">POST</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -232,12 +350,12 @@ log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
             <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
             <boolProp name="HTTPSampler.md5">false</boolProp>
             <intProp name="HTTPSampler.ipSourceType">0</intProp>
-            <stringProp name="TestPlan.comments">add random number of items (1 to 5) of the previously selected product </stringProp>
+            <stringProp name="TestPlan.comments">start the saga</stringProp>
           </HTTPSamplerProxy>
           <hashTree>
             <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
               <collectionProp name="HeaderManager.headers">
-                <elementProp name="" elementType="Header">
+                <elementProp name="Content-Type" elementType="Header">
                   <stringProp name="Header.name">Content-Type</stringProp>
                   <stringProp name="Header.value">application/json</stringProp>
                 </elementProp>
@@ -246,64 +364,7 @@ log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
             <hashTree/>
           </hashTree>
         </hashTree>
-        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
-          <boolProp name="IfController.evaluateAll">false</boolProp>
-          <boolProp name="IfController.useExpression">true</boolProp>
-          <stringProp name="IfController.condition">${logging_enabled}</stringProp>
-        </IfController>
-        <hashTree>
-          <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG REQUEST" enabled="true">
-            <stringProp name="cacheKey">true</stringProp>
-            <stringProp name="filename"></stringProp>
-            <stringProp name="parameters"></stringProp>
-            <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
-def note = &quot;POST confirm order&quot;
-
-log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
-</stringProp>
-            <stringProp name="scriptLanguage">groovy</stringProp>
-          </JSR223Sampler>
-          <hashTree/>
-        </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="confirm order" enabled="true">
-          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="" elementType="HTTPArgument">
-                <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{&quot;cardNumber&quot;:&quot;cardNumber&quot;,&quot;cardOwner&quot;:&quot;cardOwner&quot;,&quot;checksum&quot;:&quot;checksum&quot;, &quot;sessionId&quot;:&quot;${sessionId}&quot;}</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
-          <stringProp name="HTTPSampler.domain">${hostname}</stringProp>
-          <stringProp name="HTTPSampler.port">${port}</stringProp>
-          <stringProp name="HTTPSampler.path">confirm</stringProp>
-          <stringProp name="HTTPSampler.method">POST</stringProp>
-          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-          <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
-          <boolProp name="HTTPSampler.image_parser">false</boolProp>
-          <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
-          <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
-          <boolProp name="HTTPSampler.md5">false</boolProp>
-          <intProp name="HTTPSampler.ipSourceType">0</intProp>
-          <stringProp name="TestPlan.comments">start the saga</stringProp>
-        </HTTPSamplerProxy>
-        <hashTree>
-          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
-            <collectionProp name="HeaderManager.headers">
-              <elementProp name="Content-Type" elementType="Header">
-                <stringProp name="Header.name">Content-Type</stringProp>
-                <stringProp name="Header.value">application/json</stringProp>
-              </elementProp>
-            </collectionProp>
-          </HeaderManager>
-          <hashTree/>
-        </hashTree>
-        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging: SCI" enabled="true">
           <boolProp name="IfController.evaluateAll">false</boolProp>
           <boolProp name="IfController.useExpression">true</boolProp>
           <stringProp name="IfController.condition">${logging_enabled}</stringProp>
@@ -320,16 +381,44 @@ log.info(&quot;${currentTimeMicroseconds} GMT_SCI_R=1&quot;)</stringProp>
           </JSR223Sampler>
           <hashTree/>
         </hashTree>
-        <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Pause between executions" enabled="true">
-          <intProp name="ActionProcessor.action">1</intProp>
-          <intProp name="ActionProcessor.target">0</intProp>
-          <stringProp name="ActionProcessor.duration">0</stringProp>
-        </TestAction>
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Pause after execution" enabled="true">
+          <boolProp name="IfController.evaluateAll">false</boolProp>
+          <boolProp name="IfController.useExpression">true</boolProp>
+          <stringProp name="IfController.condition">${__groovy(vars.get(&quot;pause_after_execution&quot;).toInteger() &gt; 0 )}</stringProp>
+        </IfController>
         <hashTree>
-          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Pause between executions" enabled="true">
-            <stringProp name="ConstantTimer.delay">${timeBetweenExecutions}</stringProp>
-          </ConstantTimer>
-          <hashTree/>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging - Pause" enabled="true">
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+            <boolProp name="IfController.useExpression">true</boolProp>
+            <stringProp name="IfController.condition">${logging_enabled}</stringProp>
+          </IfController>
+          <hashTree>
+            <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG PAUSE" enabled="true">
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
+def pause = Integer.parseInt(vars.get(&quot;pause_after_execution&quot;))
+
+if (pause &gt; 0) {
+	log.info(&quot;${currentTimeMicroseconds} pause after execution: ${pause} ms&quot;)
+}
+</stringProp>
+              <stringProp name="scriptLanguage">groovy</stringProp>
+            </JSR223Sampler>
+            <hashTree/>
+          </hashTree>
+          <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Pause after execution" enabled="true">
+            <intProp name="ActionProcessor.action">1</intProp>
+            <intProp name="ActionProcessor.target">0</intProp>
+            <stringProp name="ActionProcessor.duration">0</stringProp>
+          </TestAction>
+          <hashTree>
+            <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Pause" enabled="true">
+              <stringProp name="ConstantTimer.delay">${pause_after_execution}</stringProp>
+            </ConstantTimer>
+            <hashTree/>
+          </hashTree>
         </hashTree>
       </hashTree>
     </hashTree>

--- a/jmeter/jmeter-test-plan.jmx
+++ b/jmeter/jmeter-test-plan.jmx
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.2">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="t2-project-flexible" enabled="true">
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="Benutzer definierte Variablen" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="hostname" elementType="Argument">
+            <stringProp name="Argument.name">hostname</stringProp>
+            <stringProp name="Argument.value">${__P(hostname)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="port" elementType="Argument">
+            <stringProp name="Argument.name">port</stringProp>
+            <stringProp name="Argument.value">${__P(port)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="num_executions" elementType="Argument">
+            <stringProp name="Argument.name">num_executions</stringProp>
+            <stringProp name="Argument.value">${__P(numExecutions,1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="num_user" elementType="Argument">
+            <stringProp name="Argument.name">num_user</stringProp>
+            <stringProp name="Argument.value">${__P(numUser,1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="ramp_up" elementType="Argument">
+            <stringProp name="Argument.name">ramp_up</stringProp>
+            <stringProp name="Argument.value">${__P(rampUp,0)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="num_products" elementType="Argument">
+            <stringProp name="Argument.name">num_products</stringProp>
+            <stringProp name="Argument.value">${__P(numProducts,1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="think_time_min" elementType="Argument">
+            <stringProp name="Argument.name">think_time_min</stringProp>
+            <stringProp name="Argument.value">${__P(thinkTimeMin,0)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="think_time_additional_range" elementType="Argument">
+            <stringProp name="Argument.name">think_time_additional_range</stringProp>
+            <stringProp name="Argument.value">${__P(thinkTimeAdditionalRange,0)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="time_between_executions" elementType="Argument">
+            <stringProp name="Argument.name">time_between_executions</stringProp>
+            <stringProp name="Argument.value">${__P(timeBetweenExecutions,0)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="logging_enabled" elementType="Argument">
+            <stringProp name="Argument.name">logging_enabled</stringProp>
+            <stringProp name="Argument.value">${__P(loggingEnabled,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </elementProp>
+      <stringProp name="TestPlan.comments">There are many parameters to configure the test plan</stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Users" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Schleifen-Controller (Loop Controller)" enabled="true">
+          <stringProp name="LoopController.loops">${num_executions}</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${num_user}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${ramp_up}</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <boolProp name="ThreadGroup.delayedStart">false</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
+          <collectionProp name="CookieManager.cookies"/>
+          <boolProp name="CookieManager.clearEachIteration">false</boolProp>
+          <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
+        </CookieManager>
+        <hashTree/>
+        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="SessionId" enabled="true">
+          <stringProp name="TestPlan.comments">fake sessionId</stringProp>
+          <stringProp name="variableName">sessionId</stringProp>
+          <stringProp name="outputFormat">ID_0000000000</stringProp>
+          <stringProp name="minimumValue">1</stringProp>
+          <stringProp name="maximumValue">2147483647</stringProp>
+          <stringProp name="randomSeed">42</stringProp>
+          <boolProp name="perThread">false</boolProp>
+        </RandomVariableConfig>
+        <hashTree/>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Adding Items to Cart" enabled="true">
+          <stringProp name="LoopController.loops">${num_products}</stringProp>
+        </LoopController>
+        <hashTree>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+            <boolProp name="IfController.useExpression">true</boolProp>
+            <stringProp name="IfController.condition">${logging_enabled}</stringProp>
+          </IfController>
+          <hashTree>
+            <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG REQUEST" enabled="true">
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
+def note = &quot;GET inventory&quot;
+
+log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
+</stringProp>
+              <stringProp name="scriptLanguage">groovy</stringProp>
+            </JSR223Sampler>
+            <hashTree/>
+          </hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="get inventory" enabled="true">
+            <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+              <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain">${hostname}</stringProp>
+            <stringProp name="HTTPSampler.port">${port}</stringProp>
+            <stringProp name="HTTPSampler.path">/products</stringProp>
+            <stringProp name="HTTPSampler.method">GET</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
+            <boolProp name="HTTPSampler.image_parser">false</boolProp>
+            <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
+            <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
+            <boolProp name="HTTPSampler.md5">false</boolProp>
+            <intProp name="HTTPSampler.ipSourceType">0</intProp>
+          </HTTPSamplerProxy>
+          <hashTree>
+            <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="get product id " enabled="true">
+              <stringProp name="RegexExtractor.useHeaders">false</stringProp>
+              <stringProp name="RegexExtractor.refname">ID</stringProp>
+              <stringProp name="RegexExtractor.regex">&quot;id&quot;:&quot;(.*?)&quot;</stringProp>
+              <stringProp name="RegexExtractor.template">$1$</stringProp>
+              <stringProp name="RegexExtractor.default">foooo</stringProp>
+              <stringProp name="RegexExtractor.match_number">0</stringProp>
+              <stringProp name="TestPlan.comments">seletct a random product id and save it to variable ID</stringProp>
+              <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
+            </RegexExtractor>
+            <hashTree/>
+          </hashTree>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+            <boolProp name="IfController.useExpression">true</boolProp>
+            <stringProp name="IfController.condition">${logging_enabled}</stringProp>
+          </IfController>
+          <hashTree>
+            <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG THINKING" enabled="true">
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
+def minThinkTime = Integer.parseInt(vars.get(&quot;think_time_min&quot;))
+def maxThinkTime = minThinkTime + Integer.parseInt(vars.get(&quot;think_time_additional_range&quot;))
+
+if (minThinkTime == maxThinkTime) {
+	log.info(&quot;${currentTimeMicroseconds} think time ${minThinkTime} ms&quot;)
+} else {
+	log.info(&quot;${currentTimeMicroseconds} think time ${minThinkTime} - ${maxThinkTime} ms&quot;)
+}
+</stringProp>
+              <stringProp name="scriptLanguage">groovy</stringProp>
+            </JSR223Sampler>
+            <hashTree/>
+          </hashTree>
+          <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Think Time" enabled="true">
+            <intProp name="ActionProcessor.action">1</intProp>
+            <intProp name="ActionProcessor.target">0</intProp>
+            <stringProp name="ActionProcessor.duration">0</stringProp>
+          </TestAction>
+          <hashTree>
+            <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Pause" enabled="true">
+              <stringProp name="ConstantTimer.delay">${think_time_min}</stringProp>
+              <stringProp name="RandomTimer.range">${think_time_additional_range}</stringProp>
+              <stringProp name="TestPlan.comments">Users typically need some amount of time to choose a product</stringProp>
+            </UniformRandomTimer>
+            <hashTree/>
+          </hashTree>
+          <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
+            <boolProp name="IfController.evaluateAll">false</boolProp>
+            <boolProp name="IfController.useExpression">true</boolProp>
+            <stringProp name="IfController.condition">${logging_enabled}</stringProp>
+          </IfController>
+          <hashTree>
+            <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG REQUEST" enabled="true">
+              <stringProp name="cacheKey">true</stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
+def note = &quot;POST add item to cart&quot;
+
+log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
+</stringProp>
+              <stringProp name="scriptLanguage">groovy</stringProp>
+            </JSR223Sampler>
+            <hashTree/>
+          </hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="add item to cart" enabled="true">
+            <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+              <collectionProp name="Arguments.arguments">
+                <elementProp name="" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">{&quot;content&quot; : { &quot;${ID}&quot; : ${__Random(1,5)}}}&#xd;
+&#xd;
+</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                </elementProp>
+              </collectionProp>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain">${hostname}</stringProp>
+            <stringProp name="HTTPSampler.port">${port}</stringProp>
+            <stringProp name="HTTPSampler.path">cart/${sessionId}</stringProp>
+            <stringProp name="HTTPSampler.method">POST</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
+            <boolProp name="HTTPSampler.image_parser">false</boolProp>
+            <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
+            <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
+            <boolProp name="HTTPSampler.md5">false</boolProp>
+            <intProp name="HTTPSampler.ipSourceType">0</intProp>
+            <stringProp name="TestPlan.comments">add random number of items (1 to 5) of the previously selected product </stringProp>
+          </HTTPSamplerProxy>
+          <hashTree>
+            <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+              <collectionProp name="HeaderManager.headers">
+                <elementProp name="" elementType="Header">
+                  <stringProp name="Header.name">Content-Type</stringProp>
+                  <stringProp name="Header.value">application/json</stringProp>
+                </elementProp>
+              </collectionProp>
+            </HeaderManager>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
+          <boolProp name="IfController.evaluateAll">false</boolProp>
+          <boolProp name="IfController.useExpression">true</boolProp>
+          <stringProp name="IfController.condition">${logging_enabled}</stringProp>
+        </IfController>
+        <hashTree>
+          <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG REQUEST" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
+def note = &quot;POST confirm order&quot;
+
+log.info(&quot;${currentTimeMicroseconds} ${note}&quot;)
+</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223Sampler>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="confirm order" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&quot;cardNumber&quot;:&quot;cardNumber&quot;,&quot;cardOwner&quot;:&quot;cardOwner&quot;,&quot;checksum&quot;:&quot;checksum&quot;, &quot;sessionId&quot;:&quot;${sessionId}&quot;}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${hostname}</stringProp>
+          <stringProp name="HTTPSampler.port">${port}</stringProp>
+          <stringProp name="HTTPSampler.path">confirm</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
+          <boolProp name="HTTPSampler.image_parser">false</boolProp>
+          <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
+          <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
+          <boolProp name="HTTPSampler.md5">false</boolProp>
+          <intProp name="HTTPSampler.ipSourceType">0</intProp>
+          <stringProp name="TestPlan.comments">start the saga</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="Content-Type" elementType="Header">
+                <stringProp name="Header.name">Content-Type</stringProp>
+                <stringProp name="Header.value">application/json</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="Logging" enabled="true">
+          <boolProp name="IfController.evaluateAll">false</boolProp>
+          <boolProp name="IfController.useExpression">true</boolProp>
+          <stringProp name="IfController.condition">${logging_enabled}</stringProp>
+        </IfController>
+        <hashTree>
+          <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="LOG GMT_SCI_R" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">def currentTimeMicroseconds = System.currentTimeMillis() * 1000
+
+log.info(&quot;${currentTimeMicroseconds} GMT_SCI_R=1&quot;)</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223Sampler>
+          <hashTree/>
+        </hashTree>
+        <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Pause between executions" enabled="true">
+          <intProp name="ActionProcessor.action">1</intProp>
+          <intProp name="ActionProcessor.target">0</intProp>
+          <stringProp name="ActionProcessor.duration">0</stringProp>
+        </TestAction>
+        <hashTree>
+          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Pause between executions" enabled="true">
+            <stringProp name="ConstantTimer.delay">${timeBetweenExecutions}</stringProp>
+          </ConstantTimer>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/jmeter/usage_scenario.yml
+++ b/jmeter/usage_scenario.yml
@@ -1,0 +1,28 @@
+---
+name: JMeter Test Plan Execution
+author: David Kopp <mail@davidkopp.de>
+description: Demonstrating the usage of JMeter executing a test plan.
+
+compose-file: !include compose.yml
+
+services:
+  gcb-postgres:
+    setup-commands:
+       - sleep 5 # wait some time to ensure that the database is ready
+  gcb-backend:
+    setup-commands:
+       - sleep 10 # wait some time to ensure that the backend is ready
+
+sci:
+  R_d: order
+  # One order consists of three sequential requests: get inventory, add product to cart, confirm order
+
+flow:
+  - name: Execute JMeter test plan # single user orders one product with a short think time of 1 second
+    container: gcb-jmeter
+    commands:
+      - type: console
+        command: jmeter -Jhostname=gcb-backend -Jport=8080 -JnumExecutions=1 -JnumUser=1 -JrampUp=0 -JnumProducts=1 -JthinkTimeMin=1000 -JthinkTimeAdditionalRange=0 -JloggingEnabled=true -n -t /tmp/repo/jmeter-test-plan.jmx
+        log-stdout: true
+        read-notes-stdout: true
+        read-sci-stdout: true

--- a/jmeter/usage_scenario.yml
+++ b/jmeter/usage_scenario.yml
@@ -22,7 +22,7 @@ flow:
     container: gcb-jmeter
     commands:
       - type: console
-        command: jmeter -Jhostname=gcb-backend -Jport=8080 -JnumExecutions=1 -JnumUser=1 -JrampUp=0 -JnumProducts=1 -JthinkTimeMin=1000 -JthinkTimeAdditionalRange=0 -JloggingEnabled=true -n -t /tmp/repo/jmeter-test-plan.jmx
+        command: jmeter -Jhostname=gcb-backend -Jport=8080 -JnumExecutions=1 -JnumUser=1 -JrampUp=0 -JnumProducts=1 -JthinkTimeMin=1000 -JthinkTimeAdditionalRange=0 -JpauseBeforeExecution=0 -JpauseAfterExecution=0 -JloggingEnabled=true -n -t /tmp/repo/jmeter-test-plan.jmx
         log-stdout: true
         read-notes-stdout: true
         read-sci-stdout: true


### PR DESCRIPTION
This example demonstrates how to use JMeter to execute a test plan that makes HTTP requests to a web application.
[Apache JMeter](https://jmeter.apache.org/) is a load and performance testing tool.

JMeter Docker image: https://hub.docker.com/r/t2project/jmeter
Example web application: [T2-Project](https://t2-documentation.readthedocs.io)
